### PR TITLE
Fix #15 Pluralization and fallback languages

### DIFF
--- a/tests/I18Next.Net.Tests/I18NextFixture.cs
+++ b/tests/I18Next.Net.Tests/I18NextFixture.cs
@@ -25,6 +25,7 @@ namespace I18Next.Net.Tests
 
             backend.AddTranslation("en", "translation", "exampleKey", "My English text.");
             backend.AddTranslation("en", "translation", "exampleKey2", "My English fallback.");
+            backend.AddTranslation("en", "translation", "exampleKey2_plural", "My English plural fallback {{count}}.");
             backend.AddTranslation("de", "translation", "exampleKey", "Mein deutscher text.");
 
             _backend = backend;
@@ -58,6 +59,14 @@ namespace I18Next.Net.Tests
             _i18Next.Language = "jp";
             _i18Next.SetFallbackLanguages("en");
             Assert.AreEqual("My English fallback.", _i18Next.T("exampleKey2"));
+        }
+
+        [Test]
+        public void Pluralization_MissingLanguage_ReturnsFallback()
+        {
+            _i18Next.Language = "ja";
+            _i18Next.SetFallbackLanguages("en");
+            Assert.AreEqual("My English plural fallback 2.", _i18Next.T("exampleKey2", new { count = 2 }));
         }
 
         [Test]

--- a/tests/I18Next.Net.Tests/Plugins/DefaultPluralResolverFixture.cs
+++ b/tests/I18Next.Net.Tests/Plugins/DefaultPluralResolverFixture.cs
@@ -1,6 +1,91 @@
-﻿namespace I18Next.Net.Tests.Plugins
+﻿using I18Next.Net.Plugins;
+using NUnit.Framework;
+
+namespace I18Next.Net.Tests.Plugins
 {
+    [TestFixture]
     public class DefaultPluralResolverFixture
     {
+        [TestCase(JsonFormat.Version1, ExpectedResult = "")]
+        [TestCase(JsonFormat.Version2, ExpectedResult = "")]
+        [TestCase(JsonFormat.Version3, ExpectedResult = "")]
+        public string GetPluralSuffix_OneInEnglish_ShouldReturnEmptyWhenUsingSimpleSuffix(JsonFormat jsonFormatVersion)
+        {
+            var pluralResolver = new DefaultPluralResolver()
+            {
+                JsonFormatVersion = jsonFormatVersion,
+                UseSimplePluralSuffixIfPossible = true
+            };
+
+            return pluralResolver.GetPluralSuffix("en", 1);
+        }
+
+        [TestCase(JsonFormat.Version1, ExpectedResult = "")]
+        [TestCase(JsonFormat.Version2, ExpectedResult = "_1")]
+        [TestCase(JsonFormat.Version3, ExpectedResult = "_0")]
+        public string GetPluralSuffix_OneInEnglish_ShouldReturnNumberWhenNotUsingSimpleSuffix(JsonFormat jsonFormatVersion)
+        {
+            var pluralResolver = new DefaultPluralResolver()
+            {
+                JsonFormatVersion = jsonFormatVersion,
+                UseSimplePluralSuffixIfPossible = false
+            };
+
+            return pluralResolver.GetPluralSuffix("en", 1);
+        }
+
+        [TestCase(JsonFormat.Version1, ExpectedResult = "_plural")]
+        [TestCase(JsonFormat.Version2, ExpectedResult = "_plural")]
+        [TestCase(JsonFormat.Version3, ExpectedResult = "_plural")]
+        public string GetPluralSuffix_TwoInEnglish_ShouldReturnPluralWhenUsingSimpleSuffix(JsonFormat jsonFormatVersion)
+        {
+            var pluralResolver = new DefaultPluralResolver()
+            {
+                JsonFormatVersion = jsonFormatVersion,
+                UseSimplePluralSuffixIfPossible = true
+            };
+
+            return pluralResolver.GetPluralSuffix("en", 2);
+        }
+
+        [TestCase(JsonFormat.Version1, ExpectedResult = "_2")]
+        [TestCase(JsonFormat.Version2, ExpectedResult = "_2")]
+        [TestCase(JsonFormat.Version3, ExpectedResult = "_1")]
+        public string GetPluralSuffix_TwoInEnglish_ShouldReturnNumberWhenNotUsingSimpleSuffix(JsonFormat jsonFormatVersion)
+        {
+            var pluralResolver = new DefaultPluralResolver()
+            {
+                JsonFormatVersion = jsonFormatVersion,
+                UseSimplePluralSuffixIfPossible = false
+            };
+
+            return pluralResolver.GetPluralSuffix("en", 2);
+        }
+
+        [TestCase(JsonFormat.Version1, ExpectedResult = "")]
+        [TestCase(JsonFormat.Version2, ExpectedResult = "")]
+        [TestCase(JsonFormat.Version3, ExpectedResult = "_0")]
+        public string GetPluralSuffix_OneInJapanese_ShouldReturnNumber(JsonFormat jsonFormatVersion)
+        {
+            var pluralResolver = new DefaultPluralResolver()
+            {
+                JsonFormatVersion = jsonFormatVersion,
+            };
+
+            return pluralResolver.GetPluralSuffix("ja", 1);
+        }
+
+        [TestCase(JsonFormat.Version1, ExpectedResult = "")]
+        [TestCase(JsonFormat.Version2, ExpectedResult = "")]
+        [TestCase(JsonFormat.Version3, ExpectedResult = "_0")]
+        public string GetPluralSuffix_TwoInJapanese_ShouldReturnNumber(JsonFormat jsonFormatVersion)
+        {
+            var pluralResolver = new DefaultPluralResolver()
+            {
+                JsonFormatVersion = jsonFormatVersion,
+            };
+
+            return pluralResolver.GetPluralSuffix("ja", 2);
+        }
     }
 }


### PR DESCRIPTION
This PR largely reverts refactoring done to DefaultTranslator.ResolveTranslationAsync that broke pluralization for fallback languages. Now the code builds the list of possible keys once for each language again instead of reusing keys that may differ between languages because of different plural rules.

It also adds support for [i18next JSON v3 format](https://www.i18next.com/misc/json-format) that changes plural suffixes for some languages. Note that this might be a breaking change, it looks like the code previously was built around v2 but I set the default to v3 now.

And finally it adds a number of tests for DefaultPluralResolver to cover these things.

Fixes #15 