### PR TITLE
Change ThreadLanguageDetector from deprecated ietf property

### DIFF
--- a/src/I18Next.Net/Plugins/ThreadLanguageDetector.cs
+++ b/src/I18Next.Net/Plugins/ThreadLanguageDetector.cs
@@ -16,9 +16,9 @@ public class ThreadLanguageDetector : ILanguageDetector
 
     public string FallbackLanguage { get; set; }
 
-    public string GetLanguage()
-    {
-        var languageTag = Thread.CurrentThread.CurrentCulture.IetfLanguageTag;
+        public string GetLanguage()
+        {
+            var languageTag = Thread.CurrentThread.CurrentCulture.Name;
 
         if (string.IsNullOrEmpty(languageTag))
             return FallbackLanguage;


### PR DESCRIPTION
Per [Microsoft documentation](https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.ietflanguagetag?view=net-6.0#remarks), the IetfLanguageTag property is deprecated. The PR switches the ThreadLanguageDetector to the recommended Name property.