### PR TITLE
Add PackageLicenseExpression and cleanup project properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+
+    <PropertyGroup>
+        <Product>I18Next.Net</Product>
+        <Authors>DarkLiKally</Authors>
+        <Company>DarkLiKally</Company>
+
+        <Version>1.0.0</Version>
+
+        <RepositoryUrl>https://github.com/DarkLiKally/I18Next.Net</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+
+        <LangVersion>latest</LangVersion>
+
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageProjectUrl>https://github.com/DarkLiKally/I18Next.Net</PackageProjectUrl>
+    </PropertyGroup>
+
+</Project>

--- a/I18Next.Net.sln
+++ b/I18Next.Net.sln
@@ -26,6 +26,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "I18Next.Net.Gettext", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "I18Next.Net.Benchmarks", "tests\I18Next.Net.Benchmarks\I18Next.Net.Benchmarks.csproj", "{28A8E334-B484-47BF-A46F-0142830C9951}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9CBEA95C-D051-4203-9EAD-DE45EC10A79E}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/samples/Example.ConsoleApp.NetFramework/Example.ConsoleApp.NetFramework.csproj
+++ b/samples/Example.ConsoleApp.NetFramework/Example.ConsoleApp.NetFramework.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Example.ConsoleApp.NetFramework</RootNamespace>
     <AssemblyName>Example.ConsoleApp.NetFramework</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/I18Next.Net.Abstractions/I18Next.Net.Abstractions.csproj
+++ b/src/I18Next.Net.Abstractions/I18Next.Net.Abstractions.csproj
@@ -2,16 +2,8 @@
 
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
-        <Product>I18Next.Net</Product>
-        <Authors>DarkLiKally</Authors>
-        <Company>DarkLiKally</Company>
-        <Version>1.0.0</Version>
-        <RepositoryUrl>https://github.com/DarkLiKally/I18Next.Net</RepositoryUrl>
-        <PackageProjectUrl>https://github.com/DarkLiKally/I18Next.Net</PackageProjectUrl>
-        <RepositoryType>git</RepositoryType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <RootNamespace>I18Next.Net</RootNamespace>
-        <LangVersion>latest</LangVersion>
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 

--- a/src/I18Next.Net.AspNetCore/I18Next.Net.AspNetCore.csproj
+++ b/src/I18Next.Net.AspNetCore/I18Next.Net.AspNetCore.csproj
@@ -3,13 +3,6 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <RepositoryUrl>https://github.com/DarkLiKally/I18Next.Net</RepositoryUrl>
-        <PackageProjectUrl>https://github.com/DarkLiKally/I18Next.Net</PackageProjectUrl>
-        <Version>1.0.0</Version>
-        <Authors>DarkLiKally</Authors>
-        <RepositoryType>git</RepositoryType>
-        <LangVersion>latest</LangVersion>
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 

--- a/src/I18Next.Net.Extensions/I18Next.Net.Extensions.csproj
+++ b/src/I18Next.Net.Extensions/I18Next.Net.Extensions.csproj
@@ -1,13 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
-        <Product>I18Next.Net</Product>
-        <Authors>DarkLiKally</Authors>
-        <Company>DarkLiKally</Company>
-        <Version>1.0.0</Version>
-        <RepositoryUrl>https://github.com/DarkLiKally/I18Next.Net</RepositoryUrl>
-        <PackageProjectUrl>https://github.com/DarkLiKally/I18Next.Net</PackageProjectUrl>
-        <RepositoryType>git</RepositoryType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
         <NoWarn>CS1591</NoWarn>

--- a/src/I18Next.Net.Gettext/I18Next.Net.Gettext.csproj
+++ b/src/I18Next.Net.Gettext/I18Next.Net.Gettext.csproj
@@ -1,16 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Company>DarkLiKally</Company>
-        <Authors>DarkLiKally</Authors>
-        <PackageProjectUrl>https://github.com/DarkLiKally/I18Next.Net</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/DarkLiKally/I18Next.Net</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <Product>I18Next.Net</Product>
-        <Version>1.0.0</Version>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
-        <LangVersion>latest</LangVersion>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 

--- a/src/I18Next.Net.ICU/I18Next.Net.ICU.csproj
+++ b/src/I18Next.Net.ICU/I18Next.Net.ICU.csproj
@@ -2,14 +2,6 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Company>DarkLiKally</Company>
-        <Authors>DarkLiKally</Authors>
-        <PackageProjectUrl>https://github.com/DarkLiKally/I18Next.Net</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/DarkLiKally/I18Next.Net</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <Product>I18Next.Net</Product>
-        <Version>1.0.0</Version>
-        <LangVersion>latest</LangVersion>
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/I18Next.Net.PolyglotJs/I18Next.Net.PolyglotJs.csproj
+++ b/src/I18Next.Net.PolyglotJs/I18Next.Net.PolyglotJs.csproj
@@ -2,14 +2,6 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Authors>DarkLiKally</Authors>
-        <Company>DarkLiKally</Company>
-        <Product>I18Next.Net</Product>
-        <PackageProjectUrl>https://github.com/DarkLiKally/I18Next.Net</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/DarkLiKally/I18Next.Net</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <Version>1.0.0</Version>
-        <LangVersion>latest</LangVersion>
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/I18Next.Net.Serilog/I18Next.Net.Serilog.csproj
+++ b/src/I18Next.Net.Serilog/I18Next.Net.Serilog.csproj
@@ -1,15 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <RepositoryUrl>https://github.com/DarkLiKally/I18Next.Net</RepositoryUrl>
-        <PackageProjectUrl>https://github.com/DarkLiKally/I18Next.Net</PackageProjectUrl>
-        <Version>1.0.0</Version>
-        <Authors>DarkLiKally</Authors>
-        <RepositoryType>git</RepositoryType>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
-        <LangVersion>latest</LangVersion>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/I18Next.Net/I18Next.Net.csproj
+++ b/src/I18Next.Net/I18Next.Net.csproj
@@ -2,13 +2,6 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <RepositoryUrl>https://github.com/DarkLiKally/I18Next.Net</RepositoryUrl>
-        <PackageProjectUrl>https://github.com/DarkLiKally/I18Next.Net</PackageProjectUrl>
-        <Version>1.0.0</Version>
-        <Authors>DarkLiKally</Authors>
-        <RepositoryType>git</RepositoryType>
-        <LangVersion>latest</LangVersion>
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
License expression is the preferred way (shows in NuGet.org and used in license validations). I created root level `Directory.Build.props` that projects will inherit so no need to have same info (in different ways) in all projects. For next release you just need to update the version number in root `Directory.Build.props`.

`dotnet build -c Release && dotnet pack -c Release` 

Now produces NuGet packages like this:

![image](https://github.com/DarkLiKally/I18Next.Net/assets/171892/379d655b-6cde-4d2c-acf0-74d4a033775c)
